### PR TITLE
Fix: l'inscription au topic MQTT devrait arriver après initialisation des fils pilotes.

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -181,12 +181,12 @@ void onMqttPublish(uint16_t packetId) {
 
 void initMqtt(void) {
   if (first_setup) {
-  mqttClient.onConnect(onMqttConnect);
-  mqttClient.onDisconnect(onMqttDisconnect);
-  mqttClient.onSubscribe(onMqttSubscribe);
-  mqttClient.onUnsubscribe(onMqttUnsubscribe);
-  mqttClient.onMessage(onMqttMessage);
-  mqttClient.onPublish(onMqttPublish);
+    mqttClient.onConnect(onMqttConnect);
+    mqttClient.onDisconnect(onMqttDisconnect);
+    mqttClient.onSubscribe(onMqttSubscribe);
+    mqttClient.onUnsubscribe(onMqttUnsubscribe);
+    mqttClient.onMessage(onMqttMessage);
+    mqttClient.onPublish(onMqttPublish);
   }
   if (strcmp(config.mqtt.host, "") != 0 && config.mqtt.port > 0) {
     mqttClient.setServer(config.mqtt.host, config.mqtt.port);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -27,6 +27,7 @@ int nbRestart = 0;
 
 void connectToMqtt() {
   DebuglnF("Connection au broker MQTT...");
+  initMqtt();
   if (!mqttClient.connected()) {
     mqttClient.connect();
   }
@@ -100,7 +101,7 @@ void onMqttConnect(bool sessionPresent) {
   DebuglnF("Connecté au broker MQTT");
   if (sessionPresent)
     nbRestart = 0;
-  
+
   // subscribe au topic set
   if (mqttClient.connected()) {
     mqttClient.subscribe(MQTT_TOPIC_SET, 2);
@@ -179,12 +180,14 @@ void onMqttPublish(uint16_t packetId) {
 }
 
 void initMqtt(void) {
+  if (first_setup) {
   mqttClient.onConnect(onMqttConnect);
   mqttClient.onDisconnect(onMqttDisconnect);
   mqttClient.onSubscribe(onMqttSubscribe);
   mqttClient.onUnsubscribe(onMqttUnsubscribe);
   mqttClient.onMessage(onMqttMessage);
   mqttClient.onPublish(onMqttPublish);
+  }
   if (strcmp(config.mqtt.host, "") != 0 && config.mqtt.port > 0) {
     mqttClient.setServer(config.mqtt.host, config.mqtt.port);
   }

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -27,7 +27,6 @@ int nbRestart = 0;
 
 void connectToMqtt() {
   DebuglnF("Connection au broker MQTT...");
-  //initMqtt();
   if (!mqttClient.connected()) {
     mqttClient.connect();
   }
@@ -103,7 +102,7 @@ void onMqttConnect(bool sessionPresent) {
     nbRestart = 0;
   
   // subscribe au topic set
-  if (!first_setup && mqttClient.connected()) {
+  if (mqttClient.connected()) {
     mqttClient.subscribe(MQTT_TOPIC_SET, 2);
   }
 

--- a/src/mqtt.h
+++ b/src/mqtt.h
@@ -33,6 +33,12 @@
 // Under MQTT_TOPIC_TINFO we are send teleinformation
 #define MQTT_TOPIC_TINFO  MQTT_TOPIC_BASE "tinfo"
 
+// Last Stand Will Message to be posted when Remora disconnect( /online 0 )
+#define MQTT_TOPIC_LSW MQTT_TOPIC_BASE "online"
+
+// Set keep alive in sec. Will also be used when Remora disconnect from broker to spawn lws message after it timeouts.
+#define MQTT_KEEP_ALIVE 10
+
 #define DELAY_PUBLISH_TINFO 1
 
 // Variables

--- a/src/remora.h
+++ b/src/remora.h
@@ -227,6 +227,7 @@ extern "C" {
 // status global de l'application
 extern uint16_t status;
 extern unsigned long uptime;
+extern bool first_setup;
 
 #ifdef ESP8266
 

--- a/src/remora_soft.cpp
+++ b/src/remora_soft.cpp
@@ -193,8 +193,8 @@ int WifiHandleConn(boolean setup = false)
     _wdt_feed();
 
     // Set OTA parameters
-     ArduinoOTA.setPort(config.ota_port);
-     ArduinoOTA.setHostname(config.host);
+     ArduinoOTA.setPort(DEFAULT_OTA_PORT);
+     ArduinoOTA.setHostname(DEFAULT_HOSTNAME);
      if (*config.ota_auth) {
        ArduinoOTA.setPassword(config.ota_auth);
      }/* else {
@@ -674,16 +674,15 @@ void mysetup()
 
   // On etteint la LED embarqué du core
   LedRGBOFF();
-  
+
   #ifdef MOD_MQTT
   // On peut maintenant initialiser MQTT et subscribe au MQTT_TOPIC_SET
-  initMqtt();
   connectToMqtt();
   #endif
 
   Debugln("Starting main loop");
   Debugflush();
-  
+
 }
 
 

--- a/src/remora_soft.cpp
+++ b/src/remora_soft.cpp
@@ -679,10 +679,6 @@ void mysetup()
   // On peut maintenant initialiser MQTT et subscribe au MQTT_TOPIC_SET
   initMqtt();
   connectToMqtt();
-  delay(100);
-  if (mqttClient.connected()) {
-    mqttClient.subscribe(MQTT_TOPIC_SET, 2);
-  }
   #endif
 
   Debugln("Starting main loop");


### PR DESCRIPTION
Je poste les commandes en "retain", pour qu'à chaque fois que Remora redémarre, il prenne bien la dernière commande envoyée par le contrôleur.
Dans le cas présent les infos récupérées à la souscription au topic sont écrasées à la fin du setup à l'initialisation des fils pilotes.